### PR TITLE
Remove temporary workaround now that the runner fix is deployed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,10 +50,6 @@ jobs:
       - name: Install CMake
         uses: ssrobins/install-cmake@main
 
-      - name: Add Python bin to PATH
-        if: matrix.name == 'ios' || matrix.name == 'macos'
-        run: echo "/Library/Frameworks/Python.framework/Versions/Current/bin" >> $GITHUB_PATH
-
       - name: Install Conan
         run: |
           pip3 install conan --pre --upgrade


### PR DESCRIPTION
Now that https://github.com/actions/runner-images/issues/6507 is fixed and deployed, remove manual add of python bin to PATH.